### PR TITLE
Add two window new covering sensor/actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Homebridge platform plugin for Busch-Jaeger SmartHome devices.
 - Raumtemperaturregler (1004)
 - Sensor/ Schaltaktor 8/8fach, REG (B008)
 - Jalousieaktor 4-fach, REG (B001)
+- Sensor/ Jalousieaktor 2/1-fach (1015)
+- Sensor/ Jalousieaktor 1/1-fach (1013
 
 # Requirements
 * Busch-Jaeger Access Point

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ BuschJaegerApPlatform.prototype.getAccessoryClass = function(deviceId) {
         case '1004':
             return 'BuschJaegerThermostatAccessory';
         case 'B001':
+        case '1015':
+        case '1013':
             return 'BuschJaegerJalousieAccessory';
         case 'B008':
             return 'BuschJaegerSchaltAktorAccessory';


### PR DESCRIPTION
They are both from the `free@home` system so they have a combined sensor/actor unit.

1015: Sensor/ Jalousieaktor 2/1-fach 
1013: Sensor/ Jalousieaktor 1/1-fach