### PR TITLE
Change channel length check

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ BuschJaegerApPlatform.prototype.transformAccessories = function(actuators) {
         let accessoryClass = this.getAccessoryClass(actuator['deviceId']);
         if (accessoryClass) {
             let service = require(path.join(__dirname, 'lib', accessoryClass));
-            if (Object.keys(actuator['channels']).length > 1) {
+            if (Object.keys(actuator['channels']).length > 0) {
                 for (let channel in actuator['channels']) {
                     if ('blacklist' in mapping && mapping['blacklist'].includes(channel)) {
                         this.log('Ignoring blacklisted accessory ' + actuator['typeName'] + ' with serial ' + serial + ' and channel ' + channel);


### PR DESCRIPTION
Without this change, I *always* get this error on my jalousie actuators:
```
Apr 11 21:58:24 raspberrypi homebridge[6589]: /home/pi/code/homebridge-buschjaeger/lib/BuschJaegerAccessory.js:59
Apr 11 21:58:24 raspberrypi homebridge[6589]:         return this.platform.actuatorInfo[this.serial]['channels'][channel]['datapoints'][datapoint];
Apr 11 21:58:24 raspberrypi homebridge[6589]:                                                                            ^
Apr 11 21:58:24 raspberrypi homebridge[6589]: TypeError: Cannot read property 'datapoints' of undefined
Apr 11 21:58:24 raspberrypi homebridge[6589]:     at BuschJaegerJalousieAccessory.getValue (/home/pi/code/homebridge-buschjaeger/lib/BuschJaegerAccessory.js:59:76)
Apr 11 21:58:24 raspberrypi homebridge[6589]:     at BuschJaegerJalousieAccessory.getCurrentPosition (/home/pi/code/homebridge-buschjaeger/lib/BuschJaegerJalousieAccessory.js:33:29)
```